### PR TITLE
feat: support running generators via path name

### DIFF
--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -99,10 +100,18 @@ func (a *NewAction) Run() error {
 		}
 	}
 
-	// Load the generator.
-	generator, err := a.Store.Load(a.Name)
-	if err != nil {
+	// The name may be a direct path to a generator on the filesystem.
+	generator, err := stamp.NewGeneratorFromPath(a.Store, a.Name)
+	if err != nil && !errors.Is(err, stamp.ErrNotFound) {
 		return err
+	}
+	// If that doesn't return a result, then it must be a named
+	// generator in the store...
+	if generator == nil {
+		generator, err = a.Store.Load(a.Name)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Update usage text w/ info from generator.

--- a/internal/stamp/generator.go
+++ b/internal/stamp/generator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/twelvelabs/termite/render"
 
+	"github.com/twelvelabs/stamp/internal/fsutil"
 	"github.com/twelvelabs/stamp/internal/pkg"
 	"github.com/twelvelabs/stamp/internal/value"
 )
@@ -15,6 +16,7 @@ import (
 var (
 	ErrNilPackage = errors.New("nil package")
 	ErrNilStore   = errors.New("nil store")
+	ErrNotFound   = errors.New("generator not found")
 
 	metaFileName = "generator.yaml"
 )
@@ -73,6 +75,22 @@ func GeneratorNameForCreate(path string) string {
 	}
 
 	return strings.Join(segments[idx:], ":")
+}
+
+// NewGeneratorFromPath returns the generator located at path (or ErrNotFound).
+func NewGeneratorFromPath(store *Store, path string) (*Generator, error) {
+	if !fsutil.PathIsDir(path) {
+		return nil, ErrNotFound
+	}
+	if fsutil.NoPathExists(filepath.Join(path, store.MetaFile)) {
+		return nil, ErrNotFound
+	}
+
+	p, err := pkg.LoadPackage(path, store.MetaFile)
+	if err != nil {
+		return nil, err
+	}
+	return NewGenerator(store, p)
 }
 
 func NewGenerator(store *Store, pkg *pkg.Package) (*Generator, error) {

--- a/internal/stamp/update_task.go
+++ b/internal/stamp/update_task.go
@@ -111,9 +111,11 @@ func (t *UpdateTask) Execute(ctx *TaskContext, values map[string]any) error {
 			ctx.Logger.Failure("fail", t.Dst.Path())
 			return ErrPathNotFound
 		case MissingConfigTouch:
-			if err := os.WriteFile(t.Dst.Path(), []byte{}, DstFileMode); err != nil {
-				ctx.Logger.Failure("fail", t.Dst.Path())
-				return err
+			if !ctx.DryRun {
+				if err := os.WriteFile(t.Dst.Path(), []byte{}, DstFileMode); err != nil {
+					ctx.Logger.Failure("fail", t.Dst.Path())
+					return err
+				}
 			}
 		default: // MissingConfigIgnore:
 			return nil


### PR DESCRIPTION
- Add the ability to invoke generators not in the store. This allows users to store generators in their project repos along side their code:
 
  ```
  stamp new ./path/to/generator
  ```

- Fixes a bug in the update task where the `--dry-run` flag was not properly respected when `dst.missing` was set to `touch`.