### PR TITLE
fix: render values passed to generator task

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,6 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDe
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.50.33 h1:/SKPJ7ZVPCFOYZyTKo5YdjeUEeOn2J2M0qfDTXWAoEU=
-github.com/aws/aws-sdk-go v1.50.33/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go v1.50.34 h1:J1LjHzWNN/yVxQDTr0NIlI5vz9xRPvWiNCjQ4+5wh58=
 github.com/aws/aws-sdk-go v1.50.34/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
@@ -916,8 +914,6 @@ google.golang.org/api v0.96.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ
 google.golang.org/api v0.97.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/api v0.98.0/go.mod h1:w7wJQLTM+wvQpNf5JyEcBoxK0RH7EDrh/L4qfsuJ13s=
 google.golang.org/api v0.100.0/go.mod h1:ZE3Z2+ZOr87Rx7dqFsdRQkRBk36kDtp/h+QpHbB7a70=
-google.golang.org/api v0.168.0 h1:MBRe+Ki4mMN93jhDDbpuRLjRddooArz4FeSObvUMmjY=
-google.golang.org/api v0.168.0/go.mod h1:gpNOiMA2tZ4mf5R9Iwf4rK/Dcz0fbdIgWYWVoxmsyLg=
 google.golang.org/api v0.169.0 h1:QwWPy71FgMWqJN/l6jVlFHUa29a7dcUy02I8o799nPY=
 google.golang.org/api v0.169.0/go.mod h1:gpNOiMA2tZ4mf5R9Iwf4rK/Dcz0fbdIgWYWVoxmsyLg=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -100,18 +99,9 @@ func (a *NewAction) Run() error {
 		}
 	}
 
-	// The name may be a direct path to a generator on the filesystem.
-	generator, err := stamp.NewGeneratorFromPath(a.Store, a.Name)
-	if err != nil && !errors.Is(err, stamp.ErrNotFound) {
+	generator, err := a.Store.Load(a.Name)
+	if err != nil {
 		return err
-	}
-	// If that doesn't return a result, then it must be a named
-	// generator in the store...
-	if generator == nil {
-		generator, err = a.Store.Load(a.Name)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Update usage text w/ info from generator.

--- a/internal/pkg/base.go
+++ b/internal/pkg/base.go
@@ -11,6 +11,8 @@ import (
 
 	// cspell:disable-line
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/twelvelabs/stamp/internal/fsutil"
 )
 
 var (
@@ -46,13 +48,19 @@ func PackagePath(root string, name string) (string, error) {
 
 // LoadPackage parses and returns the package at `pkgPath`.
 func LoadPackage(pkgPath string, metaFile string) (*Package, error) {
-	// Ensure package path exists.
-	if _, err := os.Stat(pkgPath); os.IsNotExist(err) {
+	// Ensure package path exists and is a directory.
+	if !fsutil.PathIsDir(pkgPath) {
+		return nil, NewNotFoundError(metaFile)
+	}
+
+	// Ensure package metadata path exists.
+	pkgMetaPath := filepath.Join(pkgPath, metaFile)
+	if fsutil.NoPathExists(pkgMetaPath) {
 		return nil, NewNotFoundError(metaFile)
 	}
 
 	// Read the package metadata file.
-	pkgMeta, err := os.ReadFile(filepath.Join(pkgPath, metaFile))
+	pkgMeta, err := os.ReadFile(pkgMetaPath)
 	if err != nil {
 		return nil, fmt.Errorf("load package: %w", err)
 	}

--- a/internal/pkg/base_test.go
+++ b/internal/pkg/base_test.go
@@ -67,7 +67,7 @@ func TestLoadPackage(t *testing.T) {
 		{
 			PackageName: "empty",
 			PackagePath: packageFixtureDir("empty"),
-			Err:         "no such file or directory",
+			Err:         "package not found",
 		},
 		{
 			PackageName: "non-parsable",

--- a/internal/stamp/generator_task.go
+++ b/internal/stamp/generator_task.go
@@ -3,6 +3,7 @@ package stamp
 import (
 	"github.com/mitchellh/copystructure"
 	"github.com/swaggest/jsonschema-go"
+	"github.com/twelvelabs/termite/render"
 
 	"github.com/twelvelabs/stamp/internal/mdutil"
 )
@@ -67,6 +68,11 @@ func (t *GeneratorTask) Execute(ctx *TaskContext, values map[string]any) error {
 		return err
 	}
 
+	renderedValues, err := render.Map(t.Values, values)
+	if err != nil {
+		return err
+	}
+
 	// Deep copy so that any value mutation done by this generator
 	// doesn't leak up to the caller.
 	copied, err := copystructure.Copy(values)
@@ -77,7 +83,7 @@ func (t *GeneratorTask) Execute(ctx *TaskContext, values map[string]any) error {
 	// Doing this here (in addition to the setting in GetGenerator) to cover
 	// the case where the same generator name is used in multiple tasks.
 	// In that scenario, `values` would contain those from the last task added.
-	for k, v := range t.Values {
+	for k, v := range renderedValues {
 		data[k] = v
 	}
 


### PR DESCRIPTION
- Ensure string values passed to generator task are rendered correctly.
- Support using filesystem paths for generator task names.

Allows for:

```
tasks:
  - type: generator
    name: ./some_base_generator
    values:
      Name: "{{ ._Item }}"
    each: "foo, bar, baz"
```
