### PR TITLE
feat: provide ability to hide generators from the list

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -85,6 +85,7 @@ words:
   - shellcheck
   - signingkey
   - sigstore
+  - simpletable
   - symwalk
   - testdata
   - testutil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/twelvelabs/stamp
 go 1.23
 
 require (
+	github.com/alexeyco/simpletable v1.0.0
 	github.com/creasty/defaults v1.8.0
 	github.com/fatih/color v1.18.0
 	github.com/gobuffalo/flect v1.0.3
@@ -13,7 +14,6 @@ require (
 	github.com/muesli/roff v0.1.0
 	github.com/ohler55/ojg v1.24.1
 	github.com/otiai10/copy v1.14.0
-	github.com/rodaine/table v1.3.0
 	github.com/spf13/cast v1.7.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
@@ -73,6 +73,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/alexeyco/simpletable v1.0.0 h1:ZQ+LvJ4bmoeHb+dclF64d0LX+7QAi7awsfCrptZrpHk=
+github.com/alexeyco/simpletable v1.0.0/go.mod h1:VJWVTtGUnW7EKbMRH8cE13SigKGx/1fO2SeeOiGeBkk=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
@@ -460,6 +462,7 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
@@ -498,11 +501,10 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rodaine/table v1.3.0 h1:4/3S3SVkHnVZX91EHFvAMV7K42AnJ0XuymRR2C5HlGE=
-github.com/rodaine/table v1.3.0/go.mod h1:47zRsHar4zw0jgxGxL9YtFfs7EGN6B/TaS+/Dmk4WxU=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -522,7 +524,6 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -530,7 +531,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/swaggest/assertjson v1.9.0 h1:dKu0BfJkIxv/xe//mkCrK5yZbs79jL7OVf9Ija7o2xQ=

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -78,9 +78,9 @@ func (a *AddAction) Run() error {
 		return err
 	}
 
-	tbl := table.New("Name", "Description", "Origin").WithWriter(a.IO.Out)
+	tbl := table.New("Name", "Description").WithWriter(a.IO.Out)
 	for _, p := range packages {
-		tbl.AddRow(p.Name(), p.Description(), p.Origin())
+		tbl.AddRow(p.Name(), p.Description())
 	}
 	tbl.Print()
 

--- a/internal/cmd/add.go
+++ b/internal/cmd/add.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
 
 	"github.com/twelvelabs/stamp/internal/stamp"
@@ -73,16 +72,11 @@ func (a *AddAction) Run() error {
 	a.UI.Out(a.UI.SuccessIcon()+" Installed package: %s\n", installed.Name())
 	a.UI.Out("\n")
 
-	packages, err := installed.All()
+	generators, err := a.Store.AsGenerators(installed.All())
 	if err != nil {
 		return err
 	}
-
-	tbl := table.New("Name", "Description").WithWriter(a.IO.Out)
-	for _, p := range packages {
-		tbl.AddRow(p.Name(), p.Description())
-	}
-	tbl.Print()
+	renderGeneratorList(generators, false, a.IO.Out)
 
 	return nil
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
+	"github.com/twelvelabs/termite/ui"
 
 	"github.com/twelvelabs/stamp/internal/stamp"
 )
@@ -53,20 +54,35 @@ func (a *ListAction) Run() error {
 		return err
 	}
 
+	renderGeneratorList(results, a.ShowAll, a.IO.Out)
+
+	return nil
+}
+
+func renderGeneratorList(
+	generators []*stamp.Generator,
+	showAll bool,
+	out ui.IOStream,
+) {
 	columns := []any{"Name", "Description"}
-	if a.ShowAll {
+	if showAll {
 		columns = append(columns, "Origin")
 	}
+	tbl := table.New(columns...).WithWriter(out)
 
-	tbl := table.New(columns...).WithWriter(a.IO.Out)
-	for _, p := range results {
-		row := []any{p.Name(), p.ShortDescription()}
-		if a.ShowAll {
-			row = append(row, p.Origin())
+	for _, g := range generators {
+		if g.IsPrivate() {
+			continue
+		}
+		if g.IsHidden() && !showAll {
+			continue
+		}
+		row := []any{g.Name(), g.ShortDescription()}
+		if showAll {
+			row = append(row, g.Origin())
 		}
 		tbl.AddRow(row...)
 	}
-	tbl.Print()
 
-	return nil
+	tbl.Print()
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -25,6 +25,8 @@ func NewListCmd(app *stamp.App) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVarP(&action.ShowAll, "all", "a", action.ShowAll, "Show all columns.")
+
 	return cmd
 }
 
@@ -36,6 +38,7 @@ func NewListAction(app *stamp.App) *ListAction {
 
 type ListAction struct {
 	*stamp.App
+	ShowAll bool
 }
 
 func (a *ListAction) Setup(_ *cobra.Command, _ []string) error {
@@ -50,9 +53,18 @@ func (a *ListAction) Run() error {
 		return err
 	}
 
-	tbl := table.New("Name", "Description", "Origin").WithWriter(a.IO.Out)
+	columns := []any{"Name", "Description"}
+	if a.ShowAll {
+		columns = append(columns, "Origin")
+	}
+
+	tbl := table.New(columns...).WithWriter(a.IO.Out)
 	for _, p := range results {
-		tbl.AddRow(p.Name(), p.ShortDescription(), p.Origin())
+		row := []any{p.Name(), p.ShortDescription()}
+		if a.ShowAll {
+			row = append(row, p.Origin())
+		}
+		tbl.AddRow(row...)
 	}
 	tbl.Print()
 

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
 
 	"github.com/twelvelabs/stamp/internal/stamp"
@@ -65,16 +64,11 @@ func (a *RemoveAction) Run() error {
 		return err
 	}
 
-	packages, err := generator.All()
+	generators, err := a.Store.AsGenerators(generator.All())
 	if err != nil {
 		return err
 	}
-
-	tbl := table.New("Name", "Description").WithWriter(a.IO.Out)
-	for _, p := range packages {
-		tbl.AddRow(p.Name(), p.Description())
-	}
-	tbl.Print()
+	renderGeneratorList(generators, false, a.IO.Out)
 
 	a.UI.Out("\n")
 	ok, err := a.UI.Confirm("Remove these packages", false)

--- a/internal/cmd/remove.go
+++ b/internal/cmd/remove.go
@@ -70,9 +70,9 @@ func (a *RemoveAction) Run() error {
 		return err
 	}
 
-	tbl := table.New("Name", "Description", "Origin").WithWriter(a.IO.Out)
+	tbl := table.New("Name", "Description").WithWriter(a.IO.Out)
 	for _, p := range packages {
-		tbl.AddRow(p.Name(), p.Description(), p.Origin())
+		tbl.AddRow(p.Name(), p.Description())
 	}
 	tbl.Print()
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,18 +1,10 @@
 package cmd
 
 import (
-	"github.com/fatih/color"
-	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
 
 	"github.com/twelvelabs/stamp/internal/stamp"
 )
-
-func init() {
-	table.DefaultHeaderFormatter = color.New(color.FgYellow, color.Underline).SprintfFunc()
-	table.DefaultFirstColumnFormatter = color.New(color.FgCyan).SprintfFunc()
-	table.DefaultPadding = 2
-}
 
 func NewRootCmd(app *stamp.App) *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,7 +11,7 @@ import (
 func init() {
 	table.DefaultHeaderFormatter = color.New(color.FgYellow, color.Underline).SprintfFunc()
 	table.DefaultFirstColumnFormatter = color.New(color.FgCyan).SprintfFunc()
-	table.DefaultPadding = 5
+	table.DefaultPadding = 2
 }
 
 func NewRootCmd(app *stamp.App) *cobra.Command {

--- a/internal/pkg/package.go
+++ b/internal/pkg/package.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/gobuffalo/flect"
 )
@@ -46,6 +47,12 @@ func (p *Package) Description() string {
 // SetName sets the package description.
 func (p *Package) SetDescription(value string) {
 	p.Metadata["Description"] = value
+}
+
+// ShortDescription returns the first line of the description.
+func (p *Package) ShortDescription() string {
+	lines := strings.Split(p.Description(), "\n")
+	return lines[0]
 }
 
 // Origin returns the path or URL used to install the package.

--- a/internal/pkg/package_test.go
+++ b/internal/pkg/package_test.go
@@ -66,6 +66,42 @@ func TestPackage_Description(t *testing.T) {
 	assert.Equal(t, "foo", p.Description())
 }
 
+func TestPackage_ShortDescription(t *testing.T) {
+	tests := []struct {
+		desc     string
+		given    string
+		expected string
+	}{
+		{
+			desc:     "empty string is a noop",
+			given:    "",
+			expected: "",
+		},
+		{
+			desc:     "single line is a noop",
+			given:    "Example description",
+			expected: "Example description",
+		},
+		{
+			desc:     "otherwise first line is returned",
+			given:    "Example description\nExtended info",
+			expected: "Example description",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			p := &Package{
+				Metadata: map[string]any{
+					"description": tt.given,
+				},
+			}
+
+			actual := p.ShortDescription()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestPackage_Origin(t *testing.T) {
 	p := &Package{
 		Metadata: map[string]any{},

--- a/internal/stamp/enums.go
+++ b/internal/stamp/enums.go
@@ -52,6 +52,16 @@ type MatchSource string
 */
 type MissingConfig string
 
+// Determines the visibility of the generator.
+/*
+	ENUM(
+		public   // Callable anywhere.
+		hidden   // Public, but hidden in the generator list.
+		private  // Only callable as a sub-generator. Never displayed.
+	).
+*/
+type VisibilityType string
+
 // Specifies the content type of the file.
 // Inferred from the file extension by default.
 //

--- a/internal/stamp/enums_enum.go
+++ b/internal/stamp/enums_enum.go
@@ -436,3 +436,106 @@ func (x MissingConfig) EnumComments() []string {
 		"Raise an error.",
 	}
 }
+
+const (
+	// Callable anywhere.
+	VisibilityTypePublic VisibilityType = "public"
+	// Public, but hidden in the generator list.
+	VisibilityTypeHidden VisibilityType = "hidden"
+	// Only callable as a sub-generator. Never displayed.
+	VisibilityTypePrivate VisibilityType = "private"
+)
+
+var ErrInvalidVisibilityType = fmt.Errorf("not a valid VisibilityType, try [%s]", strings.Join(_VisibilityTypeNames, ", "))
+
+var _VisibilityTypeNames = []string{
+	string(VisibilityTypePublic),
+	string(VisibilityTypeHidden),
+	string(VisibilityTypePrivate),
+}
+
+// VisibilityTypeNames returns a list of possible string values of VisibilityType.
+func VisibilityTypeNames() []string {
+	tmp := make([]string, len(_VisibilityTypeNames))
+	copy(tmp, _VisibilityTypeNames)
+	return tmp
+}
+
+// String implements the Stringer interface.
+func (x VisibilityType) String() string {
+	return string(x)
+}
+
+// IsValid provides a quick way to determine if the typed value is
+// part of the allowed enumerated values
+func (x VisibilityType) IsValid() bool {
+	_, err := ParseVisibilityType(string(x))
+	return err == nil
+}
+
+var _VisibilityTypeValue = map[string]VisibilityType{
+	"public":  VisibilityTypePublic,
+	"hidden":  VisibilityTypeHidden,
+	"private": VisibilityTypePrivate,
+}
+
+// ParseVisibilityType attempts to convert a string to a VisibilityType.
+func ParseVisibilityType(name string) (VisibilityType, error) {
+	if x, ok := _VisibilityTypeValue[name]; ok {
+		return x, nil
+	}
+	return VisibilityType(""), fmt.Errorf("%s is %w", name, ErrInvalidVisibilityType)
+}
+
+// MarshalText implements the text marshaller method.
+func (x VisibilityType) MarshalText() ([]byte, error) {
+	return []byte(string(x)), nil
+}
+
+// UnmarshalText implements the text unmarshaller method.
+func (x *VisibilityType) UnmarshalText(text []byte) error {
+	tmp, err := ParseVisibilityType(string(text))
+	if err != nil {
+		return err
+	}
+	*x = tmp
+	return nil
+}
+
+var (
+	_ jsonschema.Described = VisibilityType("")
+	_ jsonschema.Enum      = VisibilityType("")
+	_ jsonschema.Preparer  = VisibilityType("")
+)
+
+// PrepareJSONSchema implements the jsonschema.Preparer interface.
+func (x VisibilityType) PrepareJSONSchema(schema *jsonschema.Schema) error {
+	schema.WithTitle("VisibilityType")
+	schema.WithDescription(x.Description())
+	schema.WithEnum(x.Enum()...)
+	schema.WithExtraPropertiesItem("enumDescriptions", x.EnumComments())
+	return nil
+}
+
+// Enum implements the jsonschema.Described interface.
+func (x VisibilityType) Description() string {
+	return `Determines the visibility of the generator.`
+}
+
+// Enum implements the jsonschema.Enum interface.
+func (x VisibilityType) Enum() []any {
+	return []any{
+		"public",
+		"hidden",
+		"private",
+	}
+}
+
+// EnumComments returns the comment associated with each enum.
+func (x VisibilityType) EnumComments() []string {
+	return []string{
+		"Callable anywhere.",
+		"Public, but hidden in the generator list.",
+		"Only callable as a sub-generator. Never displayed.",
+	}
+}

--- a/internal/stamp/enums_enum_test.go
+++ b/internal/stamp/enums_enum_test.go
@@ -70,6 +70,26 @@ func TestMissingConfig(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestVisibilityType(t *testing.T) {
+	name := VisibilityTypeNames()[0]
+	enum := VisibilityType(name)
+
+	assert.Equal(t, true, enum.IsValid())
+	assert.Equal(t, name, enum.String())
+
+	buf, err := enum.MarshalText()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(name), buf)
+
+	err = (&enum).UnmarshalText(buf)
+	assert.NoError(t, err)
+	err = (&enum).UnmarshalText([]byte{})
+	assert.Error(t, err)
+
+	err = enum.PrepareJSONSchema(&jsonschema.Schema{})
+	assert.NoError(t, err)
+}
+
 func TestFileType(t *testing.T) {
 	name := FileTypeNames()[0]
 	enum := FileType(name)

--- a/internal/stamp/generator.go
+++ b/internal/stamp/generator.go
@@ -192,10 +192,16 @@ type Generator struct {
 	Tasks      *TaskSet
 }
 
-// ShortDescription returns the first line of the description.
-func (g *Generator) ShortDescription() string {
-	lines := strings.Split(g.Description(), "\n")
-	return lines[0]
+func (g *Generator) IsHidden() bool {
+	return g.Visibility == VisibilityTypeHidden
+}
+
+func (g *Generator) IsPublic() bool {
+	return g.Visibility == VisibilityTypePublic
+}
+
+func (g *Generator) IsPrivate() bool {
+	return g.Visibility == VisibilityTypePrivate
 }
 
 func (g *Generator) SrcPath() string {

--- a/internal/stamp/generator.go
+++ b/internal/stamp/generator.go
@@ -102,9 +102,19 @@ func NewGenerator(store *Store, pkg *pkg.Package) (*Generator, error) {
 	}
 
 	gen := &Generator{
-		Package: pkg,
-		Values:  value.NewValueSet(),
-		Tasks:   NewTaskSet(),
+		Package:    pkg,
+		Visibility: VisibilityTypePublic,
+		Values:     value.NewValueSet(),
+		Tasks:      NewTaskSet(),
+	}
+
+	visStr := gen.MetadataString("visibility")
+	if visStr != "" {
+		vis, err := ParseVisibilityType(visStr)
+		if err != nil {
+			return nil, fmt.Errorf("generator metadata invalid: %w", err)
+		}
+		gen.Visibility = vis
 	}
 
 	for _, tm := range gen.taskMetadata() {
@@ -177,8 +187,9 @@ func NewGenerators(store *Store, packages []*pkg.Package) ([]*Generator, error) 
 type Generator struct {
 	*pkg.Package
 
-	Values *value.ValueSet
-	Tasks  *TaskSet
+	Visibility VisibilityType
+	Values     *value.ValueSet
+	Tasks      *TaskSet
 }
 
 // ShortDescription returns the first line of the description.

--- a/internal/stamp/generator_metadata.go
+++ b/internal/stamp/generator_metadata.go
@@ -9,10 +9,11 @@ import (
 
 // GeneratorMetadata represents the structure of the generator.yaml file.
 type GeneratorMetadata struct {
-	Name        string        `mapstructure:"name" required:"true"`
-	Description string        `mapstructure:"description"`
-	Values      []value.Value `mapstructure:"values"`
-	Tasks       []TaskSchema  `mapstructure:"tasks"`
+	Name        string         `mapstructure:"name" required:"true"`
+	Description string         `mapstructure:"description"`
+	Visibility  VisibilityType `mapstructure:"visibility" default:"public"`
+	Values      []value.Value  `mapstructure:"values"`
+	Tasks       []TaskSchema   `mapstructure:"tasks"`
 }
 
 var _ jsonschema.Preparer = &GeneratorMetadata{}
@@ -95,6 +96,10 @@ func (m *GeneratorMetadata) PrepareJSONSchema(schema *jsonschema.Schema) error {
 				"The first line is shown when listing all generators. " +
 				"The full description is used when viewing generator help/usage text.",
 		)
+
+	schema.Properties["visibility"].TypeObject.
+		WithTitle("Visibility").
+		WithDescription("How the generator may be viewed or invoked.")
 
 	schema.Properties["values"].TypeObject.
 		WithTitle("Values").

--- a/internal/stamp/generator_test.go
+++ b/internal/stamp/generator_test.go
@@ -146,44 +146,6 @@ func TestGenerator_Description(t *testing.T) {
 	assert.Equal(t, "a test generator", gen.Description())
 }
 
-func TestGenerator_ShortDescription(t *testing.T) {
-	tests := []struct {
-		desc     string
-		given    string
-		expected string
-	}{
-		{
-			desc:     "empty string is a noop",
-			given:    "",
-			expected: "",
-		},
-		{
-			desc:     "single line is a noop",
-			given:    "Example description",
-			expected: "Example description",
-		},
-		{
-			desc:     "otherwise first line is returned",
-			given:    "Example description\nExtended info",
-			expected: "Example description",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			gen := &Generator{
-				Package: &pkg.Package{
-					Metadata: map[string]any{
-						"description": tt.given,
-					},
-				},
-			}
-
-			actual := gen.ShortDescription()
-			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
 func TestGenerator_SrcPath(t *testing.T) {
 	store := NewTestStore()
 	gen, err := store.Load("file")

--- a/internal/stamp/generator_test.go
+++ b/internal/stamp/generator_test.go
@@ -19,7 +19,25 @@ func TestNewGenerator(t *testing.T) {
 	_, err = NewGenerator(store, nil)
 	assert.ErrorContains(t, err, "nil package")
 
-	p := &pkg.Package{
+	var p *pkg.Package
+
+	p = &pkg.Package{
+		Metadata: map[string]any{
+			"visibility": "hidden",
+		},
+	}
+	_, err = NewGenerator(store, p)
+	assert.NoError(t, err)
+
+	p = &pkg.Package{
+		Metadata: map[string]any{
+			"visibility": "purple",
+		},
+	}
+	_, err = NewGenerator(store, p)
+	assert.ErrorContains(t, err, "generator metadata invalid")
+
+	p = &pkg.Package{
 		Metadata: map[string]any{
 			"values": []any{
 				map[string]any{

--- a/internal/stamp/store.go
+++ b/internal/stamp/store.go
@@ -14,18 +14,28 @@ func NewStore(root string) *Store {
 	}
 }
 
-func (s *Store) Load(name string) (*Generator, error) {
-	pkg, err := s.Store.Load(name)
+// AsGenerator returns pkg wrapped in a Generator type or err.
+// Useful when calling [pkg.Store] methods that normally return a [pkg.Package].
+func (s *Store) AsGenerator(pkg *pkg.Package, err error) (*Generator, error) {
 	if err != nil {
 		return nil, err
 	}
 	return NewGenerator(s, pkg)
 }
 
-func (s *Store) LoadAll() ([]*Generator, error) {
-	packages, err := s.Store.LoadAll()
+// AsGenerators returns packages wrapped in Generator types or err.
+// Useful when calling [pkg.Store] methods that normally return a slice of [pkg.Package] types.
+func (s *Store) AsGenerators(packages []*pkg.Package, err error) ([]*Generator, error) {
 	if err != nil {
 		return nil, err
 	}
 	return NewGenerators(s, packages)
+}
+
+func (s *Store) Load(name string) (*Generator, error) {
+	return s.AsGenerator(s.Store.Load(name))
+}
+
+func (s *Store) LoadAll() ([]*Generator, error) {
+	return s.AsGenerators(s.Store.LoadAll())
 }


### PR DESCRIPTION
- Adds a `visibility` attribute to generators (default `public`):

```go
	ENUM(
		public   // Callable anywhere.
		hidden   // Public, but hidden in the generator list.
		private  // Only callable as a sub-generator. Never displayed.
	)
```

- Adds an `-a/--all` flag to the `stamp list` command for including hidden generators.
